### PR TITLE
Provide consumer policies API

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/lushauth/README.md
+++ b/lushauth/README.md
@@ -1,0 +1,76 @@
+# LUSH Core Authentication
+This package is used to deal with authenticated requests and responses within the LUSH infrastructure.
+
+## Policies
+Policies should be used to structure access control inside a project's domain logic.
+
+### Roles Policy
+Given that you have an action that can only be performed by administrators, you can set up a `RolePolicy` with the `"admin"` role. This will permit the consumer access only if they possess one or more of the roles specified in the policy.
+
+```go
+policy := lushauth.RolePolicy{"admin", "staff"}
+policy.Permit(consumer)
+```
+
+### Grants Policy
+For more granular access control you can require grants to be set in the consumer. Given that you've got an action to delete a user, you can set up a `GrantPolicy` with the `"users.delete"` grant. This will permit the consumer access only if they possess one or more grants specified in the policy.
+
+```go
+policy := lushauth.GrantPolicy{"users.delete"}
+policy.Permit(consumer)
+```
+
+### User Policy
+Sometimes actions are bound to only be performed by a very specific user. Given that you have an action for a user to update their own profile, you can set up a `UserPolicy` with the UUID of the user. This will permit the consumer access only if their UUID match any of the UUIDs specified in the policy.
+
+```go
+policy := lushauth.UserPolicy{
+    UserID, // UserID: "5d4b32f9-5954-41c3-a470-7d76317635a7"
+}
+policy.Permit(consumer)
+```
+
+### Market Policy
+For certain things you need to allow access per market and roles in those markets. Given that you've got an action to set a price for a product in the British market, you can set up a `MarketPolicy` with the `"gb"` market id and the `"digital_manager"` market role. This will permit the consumer access only if they belong to the given market and that they possess one or more of the roles for the given market.
+
+```go
+policy := lushauth.MarketPolicy{
+    ID: "gb",
+    Roles: []string{
+        "digital_manager",
+    },
+}
+policy.Permit(consumer)
+```
+
+### Any Policy
+Sometimes you might have different access criteria for a given action. Given that you have an action to update a page for the Swedish market which can only be done by a digital manager within that market, _OR_ by a global administrator, you can set up multiple policies. This will permit the consumer access only if they're permitted access within any of the policies.
+
+```go
+policy := lushauth.AnyPolicy{
+    lushauth.MarketPolicy{
+        ID: "gb",
+        Roles: []string{
+            "digital_manager",
+        },
+    },
+    lushauth.RolePolicy{"admin"},
+}
+policy.Permit(consumer)
+```
+
+### All Policy
+Sometimes you need more than one criteria for access criteria for a given action. Given that you have an action for going into maintenance mode in the Netherlands where you want to ensure only a specific intersection of people with the global `"admin"` role and the `"digital_manager"` role within the market. This will permit the consumer access only if they're permitted by all policies.
+
+```go
+policy := lushauth.AllPolicy{
+    lushauth.MarketPolicy{
+        ID: "nl",
+        Roles: []string{
+            "digital_manager",
+        },
+    },
+    lushauth.RolePolicy{"admin"},
+}
+policy.Permit(consumer)
+```

--- a/lushauth/policy.go
+++ b/lushauth/policy.go
@@ -1,0 +1,115 @@
+package lushauth
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Permitter defines the behavior of allowing access.
+type Permitter interface {
+	Permit(c Consumer) error
+}
+
+// UserPolicy defines what users to grant access for.
+type UserPolicy []string
+
+// Permit a consumer or return an error.
+func (p UserPolicy) Permit(c Consumer) error {
+	if !c.HasAnyUUID(p...) {
+		return p
+	}
+	return nil
+}
+
+func (p UserPolicy) Error() string {
+	return fmt.Sprintf("need to be a specific user")
+}
+
+// RolePolicy defines what roles to grant access for.
+type RolePolicy []string
+
+// Permit a consumer or return an error.
+func (p RolePolicy) Permit(c Consumer) error {
+	if !c.HasAnyRole(p...) {
+		return p
+	}
+	return nil
+}
+
+func (p RolePolicy) Error() string {
+	return fmt.Sprintf("need to have any of the %s roles", strings.Join(quote(p...), ", "))
+}
+
+// GrantPolicy defines what grants required for access.
+type GrantPolicy []string
+
+// Permit a consumer or return an error.
+func (p GrantPolicy) Permit(c Consumer) error {
+	if !c.HasAnyGrant(p...) {
+		return p
+	}
+	return nil
+}
+
+func (p GrantPolicy) Error() string {
+	return fmt.Sprintf("need to have any of the %s grants", strings.Join(quote(p...), ", "))
+}
+
+// MarketPolicy defines what roles to allow access for in a given market.
+type MarketPolicy struct {
+	ID    string
+	Roles []string
+}
+
+// Permit a consumer or return an error.
+func (p MarketPolicy) Permit(c Consumer) error {
+	if !c.HasAnyMarketRole(p.ID, p.Roles...) {
+		return p
+	}
+	return nil
+}
+
+func (p MarketPolicy) Error() string {
+	return fmt.Sprintf("need to be a part of the %q market with any of the %s market roles", p.ID, strings.Join(quote(p.Roles...), ", "))
+}
+
+// AnyPolicy defines a policy made up of multiple other policies where any of them will permit access.
+type AnyPolicy []Permitter
+
+// Permit a consumer or return an error.
+func (p AnyPolicy) Permit(c Consumer) error {
+	var errs []error
+	for _, policy := range p {
+		if err := policy.Permit(c); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		return nil
+	}
+	if len(errs) >= 1 {
+		return errs[0]
+	}
+	return nil
+}
+
+// AllPolicy defines a policy made up of multiple other policies where all of them are required for access to be permitted.
+type AllPolicy []Permitter
+
+// Permit a consumer or return an error.
+func (p AllPolicy) Permit(c Consumer) error {
+	for _, policy := range p {
+		if err := policy.Permit(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// quote will take a slice of strings and quote each of them
+func quote(unquoted ...string) []string {
+	quoted := make([]string, len(unquoted))
+	for i, s := range unquoted {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return quoted
+}

--- a/lushauth/policy_test.go
+++ b/lushauth/policy_test.go
@@ -1,0 +1,356 @@
+package lushauth_test
+
+import (
+	"testing"
+
+	"github.com/LUSHDigital/core-lush/lushauth"
+	"github.com/LUSHDigital/core/test"
+	"github.com/LUSHDigital/uuid"
+)
+
+var (
+	GuestID      = uuid.Must(uuid.NewV4()).String()
+	PolicyUserID = uuid.Must(uuid.NewV4()).String()
+
+	Guest = lushauth.Consumer{
+		UUID:    GuestID,
+		Roles:   []string{},
+		Markets: []lushauth.Market{},
+	}
+	Staff = lushauth.Consumer{
+		UUID:  PolicyUserID,
+		Roles: []string{"staff"},
+		Markets: []lushauth.Market{
+			{
+				ID:    "gb",
+				Roles: []string{"staff"},
+			},
+		},
+	}
+	Manager = lushauth.Consumer{
+		UUID:  PolicyUserID,
+		Roles: []string{"staff"},
+		Markets: []lushauth.Market{
+			{
+				ID:    "gb",
+				Roles: []string{"manager"},
+			},
+			{
+				ID:    "se",
+				Roles: []string{"manager"},
+			},
+		},
+	}
+	Admin = lushauth.Consumer{
+		UUID:   PolicyUserID,
+		Roles:  []string{"admin"},
+		Grants: []string{"users.delete", "users.create"},
+		Markets: []lushauth.Market{
+			{
+				ID:    "gb",
+				Roles: []string{"manager"},
+			},
+		},
+	}
+	Deleter = lushauth.Consumer{
+		UUID:   PolicyUserID,
+		Grants: []string{"users.delete"},
+	}
+)
+
+func ExampleRolePolicy() {
+	policy := lushauth.RolePolicy{"admin", "staff"}
+	policy.Permit(consumer)
+}
+
+func TestRolePolicy_Permit(t *testing.T) {
+	var (
+		StaffPolicy = lushauth.RolePolicy{"admin", "staff"}
+		AdminPolicy = lushauth.RolePolicy{"admin"}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "staff policy with permitted consumer",
+			consumer: Staff,
+			policy:   StaffPolicy,
+			expected: nil,
+		},
+		{
+			name:     "staff policy with consumer lacking staff role",
+			consumer: Guest,
+			policy:   StaffPolicy,
+			expected: StaffPolicy,
+		},
+		{
+			name:     "admin policy with permitted consumer",
+			consumer: Admin,
+			policy:   AdminPolicy,
+			expected: nil,
+		},
+		{
+			name:     "admin policy with consumer lacking admin role",
+			consumer: Staff,
+			policy:   AdminPolicy,
+			expected: AdminPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+func ExampleGrantPolicy() {
+	policy := lushauth.GrantPolicy{"users.delete"}
+	policy.Permit(consumer)
+}
+
+func TestGrantPolicy_Permit(t *testing.T) {
+	var (
+		DeleteUsersPolicy = lushauth.GrantPolicy{"users.delete"}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "delete users policy with permitted consumer",
+			consumer: Deleter,
+			policy:   DeleteUsersPolicy,
+			expected: nil,
+		},
+		{
+			name:     "delete users policy with consumer lacking staff role",
+			consumer: Guest,
+			policy:   DeleteUsersPolicy,
+			expected: DeleteUsersPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+var UserID string
+
+func ExampleUserPolicy() {
+	policy := lushauth.UserPolicy{
+		UserID, // UserID: "5d4b32f9-5954-41c3-a470-7d76317635a7"
+	}
+	policy.Permit(consumer)
+}
+
+func TestUserPolicy_Permit(t *testing.T) {
+	var (
+		SpecificUserPolicy = lushauth.UserPolicy{PolicyUserID}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "specific user policy with permitted consumer",
+			consumer: Staff,
+			policy:   SpecificUserPolicy,
+			expected: nil,
+		},
+		{
+			name:     "specific user policy with consumer not matching",
+			consumer: Guest,
+			policy:   SpecificUserPolicy,
+			expected: SpecificUserPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+func ExampleMarketPolicy() {
+	policy := lushauth.MarketPolicy{
+		ID: "gb",
+		Roles: []string{
+			"admin",
+			"manager",
+			"staff",
+		},
+	}
+	policy.Permit(consumer)
+}
+
+func TestMarketPolicy_Permit(t *testing.T) {
+	var (
+		BritishMarketPolicy = lushauth.MarketPolicy{
+			ID:    "gb",
+			Roles: []string{"manager"},
+		}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "british market with permitted consumer",
+			consumer: Admin,
+			policy:   BritishMarketPolicy,
+			expected: nil,
+		},
+		{
+			name:     "british market with consumer not part of the market",
+			consumer: Guest,
+			policy:   BritishMarketPolicy,
+			expected: BritishMarketPolicy,
+		},
+		{
+			name:     "british market with consumer part of the market but lacking the role",
+			consumer: Guest,
+			policy:   BritishMarketPolicy,
+			expected: BritishMarketPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+func ExampleAnyPolicy() {
+	policy := lushauth.AnyPolicy{
+		lushauth.GrantPolicy{"users.delete"},
+		lushauth.RolePolicy{"admin"},
+	}
+	policy.Permit(consumer)
+}
+
+func TestAnyPolicy_Permit(t *testing.T) {
+	var (
+		GBPolicy = lushauth.MarketPolicy{
+			ID:    "gb",
+			Roles: []string{"staff"},
+		}
+		SEPolicy = lushauth.MarketPolicy{
+			ID:    "se",
+			Roles: []string{"staff"},
+		}
+		AnyMarketPolicy = lushauth.AnyPolicy{
+			GBPolicy,
+			SEPolicy,
+		}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "any of no policies",
+			consumer: Guest,
+			policy:   lushauth.AnyPolicy{},
+		},
+		{
+			name:     "any of two markets with permitted user",
+			consumer: Staff,
+			policy:   AnyMarketPolicy,
+		},
+		{
+			name:     "any of two markets with user not part of any of the markets",
+			consumer: Guest,
+			policy:   AnyMarketPolicy,
+			expected: GBPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+func ExampleAllPolicy() {
+	policy := lushauth.AllPolicy{
+		lushauth.RolePolicy{"staff"},
+		lushauth.MarketPolicy{
+			ID:    "gb",
+			Roles: []string{"manager"},
+		},
+	}
+	policy.Permit(consumer)
+}
+
+func TestAllPolicy_Permit(t *testing.T) {
+	var (
+		GBPolicy = lushauth.MarketPolicy{
+			ID:    "gb",
+			Roles: []string{"staff", "manager"},
+		}
+		SEPolicy = lushauth.MarketPolicy{
+			ID:    "se",
+			Roles: []string{"staff", "manager"},
+		}
+		AllMarketsPolicy = lushauth.AllPolicy{
+			GBPolicy,
+			SEPolicy,
+		}
+	)
+	type Test struct {
+		name     string
+		consumer lushauth.Consumer
+		policy   lushauth.Permitter
+		expected error
+	}
+	cases := []Test{
+		{
+			name:     "all of no policies",
+			consumer: Guest,
+			policy:   lushauth.AllPolicy{},
+		},
+		{
+			name:     "all of two markets with permitted user",
+			consumer: Manager,
+			policy:   AllMarketsPolicy,
+		},
+		{
+			name:     "all of two markets with user only part of one of the markets",
+			consumer: Staff,
+			policy:   AllMarketsPolicy,
+			expected: SEPolicy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			AssertPermit(t, c.expected, c.policy, c.consumer)
+		})
+	}
+}
+
+func AssertPermit(t *testing.T, expected error, p lushauth.Permitter, c lushauth.Consumer) {
+	t.Helper()
+	err := p.Permit(c)
+	if err != nil {
+		t.Log(err)
+	}
+	test.Equals(t, expected, err)
+}


### PR DESCRIPTION
## Policies
Policies should be used to structure access control inside a project's domain logic.

### Roles Policy
Given that you have an action that can only be performed by administrators, you can set up a `RolePolicy` with the `"admin"` role. This will permit the consumer access only if they possess one or more of the roles specified in the policy.

```go
policy := lushauth.RolePolicy{"admin", "staff"}
policy.Permit(consumer)
```

### Grants Policy
For more granular access control you can require grants to be set in the consumer. Given that you've got an action to delete a user, you can set up a `GrantPolicy` with the `"users.delete"` grant. This will permit the consumer access only if they possess one or more grants specified in the policy.

```go
policy := lushauth.GrantPolicy{"users.delete"}
policy.Permit(consumer)
```

### User Policy
Sometimes actions are bound to only be performed by a very specific user. Given that you have an action for a user to update their own profile, you can set up a `UserPolicy` with the UUID of the user. This will permit the consumer access only if their UUID match any of the UUIDs specified in the policy.

```go
policy := lushauth.UserPolicy{
    UserID, // UserID: "5d4b32f9-5954-41c3-a470-7d76317635a7"
}
policy.Permit(consumer)
```

### Market Policy
For certain things you need to allow access per market and roles in those markets. Given that you've got an action to set a price for a product in the British market, you can set up a `MarketPolicy` with the `"gb"` market id and the `"digital_manager"` market role. This will permit the consumer access only if they belong to the given market and that they possess one or more of the roles for the given market.

```go
policy := lushauth.MarketPolicy{
    ID: "gb",
    Roles: []string{
        "digital_manager",
    },
}
policy.Permit(consumer)
```

### Any Policy
Sometimes you might have different access criteria for a given action. Given that you have an action to update a page for the Swedish market which can only be done by a digital manager within that market, _OR_ by a global administrator, you can set up multiple policies. This will permit the consumer access only if they're permitted access within any of the policies.

```go
policy := lushauth.AnyPolicy{
    lushauth.MarketPolicy{
        ID: "gb",
        Roles: []string{
            "digital_manager",
        },
    },
    lushauth.RolePolicy{"admin"},
}
policy.Permit(consumer)
```

### All Policy
Sometimes you need more than one criteria for access criteria for a given action. Given that you have an action for going into maintenance mode in the Netherlands where you want to ensure only a specific intersection of people with the global `"admin"` role and the `"digital_manager"` role within the market. This will permit the consumer access only if they're permitted by all policies.

```go
policy := lushauth.AllPolicy{
    lushauth.MarketPolicy{
        ID: "nl",
        Roles: []string{
            "digital_manager",
        },
    },
    lushauth.RolePolicy{"admin"},
}
policy.Permit(consumer)
```